### PR TITLE
Remove trailing slashes from server url

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: "Bundesamt für Bevölkerungsschutz: NINA API"
 
 servers:
-  - url: "https://warnung.bund.de/api31/"
+  - url: "https://warnung.bund.de/api31"
 
 paths:
   /dashboard/{AGS}.json:


### PR DESCRIPTION
According to the OpenAPI specifications, the server addresses must not end on a slash (see https://swagger.io/specification/#server-object). Importing this in tools like Postman generates defective URLs containing two slashes. This PR fixes this.