### PR TITLE
fixed dashboard tag

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21,7 +21,7 @@ paths:
       summary: Meldungsübersicht nach AGS
       description: "Erhalten Sie die aktuellen Warnmeldungen für eine bestimmte Region."
       tags:
-        - Covid
+        - Warnings
       responses:
         "200":
           description: OK


### PR DESCRIPTION
The dashboard route has the wrong tag -> Covid instead of Warnings. 

This PR fixes this. 